### PR TITLE
Add quick-start and guidelines to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,59 @@
 
 ## Usage
 Use this repo to collect and structure resources from
-- information from lectures
-- external resources
-- related material and references
-- anything else you think your classmates might find valuable
+- Information from lectures
+- External resources
+- Related material and references
+- Anything else you think your classmates might find valuable
 
 ## Collaboration
-You are free to collaborate and structure resources in any way you want but keep in mind that you have to do it together and think of this as an exercise to build a valuable resource for everyone in the class. 
+You are free to collaborate and structure resources in any way you want but keep in mind that you have to do it together. Think of this as an exercise to build a valuable resource for everyone in the class! 
 
-### Suggesting resources and structure
-- Please use issues and pull requests using the [project](https://github.com/bjornwann/fullstack-2020-resources/projects/1) when you submit them so you can track them in the project. 
-- Have at least one person to review your pull requests (preferably not bjornwann)
-- Structure resources in markdown files and try to have different files for different subjects, however this structure might have to change during the process so try to not do too many changes in a single commit
-- use branches for larger structural changes and have several people review them before commiting
-- TIP: clone the repo and branch it and use VS-code to do larger commits to several files
+### Guidelines for suggesting resources and structure changes
+- Use issues and pull requests linked to [this project](https://github.com/bjornwann/fullstack-2020-resources/projects/1) to suggest changes in order to keep track of them. 
+- Have **at least one** person to *review* your pull requests (preferably not bjornwann)
+- Structure resources in *markdown files* and try to have different files for different subjects. This structure might have to change during the process so try to not do too many changes in a single commit!
+- Use branches for larger structural changes and have several people review them before commiting.
+- TIP: clone the repo, branch it and use VS-code to do larger commits to several files!
+
+### Quick-start
+1. Open the [project board](https://github.com/bjornwann/fullstack-2020-resources/projects/1) and create a new note in the **Todo** list.
+2. Add a fitting title, preferably describing your feature request or goal in 10 words or less.
+3. Create the note, click the three dots in the its upper right hand corner and select `Convert to Issue`.
+4. Click the title of the card and select `Go to issue for full details` in the bottom right corner. ( Or open the issue manually )
+5. (Optional) Select a fitting label from the side menu. Is this a `Question`, an `Enhancement` or is `Help wanted`?
+
+If you intend to do something about this issue yourself, please follow these additional instructions.
+1. Self-assign your account to the issue by clicking `Self-assign` in the sidemenu. This helps other collaborators to see wether someone is already working on this issue or not.
+2. Start working on your solution. To determine wether to use a commit or a pull request, ask yourself the following question: Is this a *minor change/fix,* or is this an *major addition to the already existing source*?
+
+#### Minor change or fix
+If the changes are considerably small, such as a typo fix or a broken link, a [commit](https://www.atlassian.com/git/tutorials/saving-changes/git-commit) is enough. Please follow the guidelines below.
+1. Clone the repository to a local folder and open it using VSCode (Or using command-line editors such as Vim or Nano)
+2. Make the required changes (Remember, only small changes should be carried out using commits)
+3. Save the changes and stage your changes. 
+4. In your commit message, provide a brief description of what you did (e.g "Fix typo") and include a reference to any issues or pull-requests linked to your change. This can be done by writing any of [the shorthands](https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords) followed by the reference number. A complete example of a commit message would be `Fix typo, closes #4`.
+5. Push your changes!
+
+#### Major addition or structure change
+If the changes are big, chances are that you will miss stuff that isn't supposed to be there or should be left untouched. This is where [pull-requests](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests) come in handy, as others will be able to review your changes *before* they make it onto the default branch (master).
+To make a PR, please follow the guidelines below.
+1. Clone the repository to a local folder (Optionally, you may [fork](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) the repository first) and open it using VSCode (Or using command-line editors such as Vim or Nano)
+2. Make a new branch and name it according to the changes you plan to make. If your intent is to add sources to the HTML & CSS `readme.md` file, you could use a title like "html&css-more-sources" or something along the lines of it.
+3. Code away! Make as many changes as you want, but **keep it together**. Don't stray away from the main objective of the issue you're trying to resolve.
+4. When you're happy with what you've accomplished (You should be! 🙌), push your changes to the new branch and visit the master branch in the browser. A message will be shown, alerting you of the fact that there are unmerged changes in a separate branch.
+5. There should be a green button labeled "Compare & pull request" - press it to create a new pull request or do so manually by opening your own branch and selecting the "Pull request" option in the upper right-hand corner.
+6. Give the PR a *good title*. It should be just as decriptive as the original issue, but different in a way as this title is supposed to indicate that you fixed the issue.
+7. Provide any additional details, questions and comments in the *body* of the PR. You might want to include a motivation for your changes, or maybe just a summary.
+8. **Assign one ore multiple reviewers**. Do **not** select them undder the "Asignees" section, but rather under the "Reviewers" one.
+9. (Optional) Add a label and link the PR to the project board under the "Projects" section. This will add a "Todo"-note on the board, indicating that your PR needs attention!
+10. Once at least one reviewer has *approved your changes*, you're free to merge the PR into the master branch. 
 
 ### Before you start
 - Think of this as an exercise to use GitHub and don't be afraid to break things. Help each other and use this opportunity to try things out in a collaborative way. 
 - Remember that this is a public repo and everyone who has the link can see it. 
 - Don't publish contact information to other students or copyrighted material
+
+## Contributors
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->


### PR DESCRIPTION
This PR adds more detailed instructions to the repository's main readme file. These instructions *should* clarify at least some of the questions that future contributors might have, as well as establish some guidelines for how commits and pull-requests should be carried out, commented, labeled, and assigned.

This would close #16 